### PR TITLE
Add Ventus 3T

### DIFF
--- a/datafiles/gliderInfo.json
+++ b/datafiles/gliderInfo.json
@@ -81,5 +81,16 @@
         "polarFileName":"Ventus 2cT.csv",
         "polarSpeedUnits":"kph",
         "polarSinkUnits":"m\/s"
+    },
+    {
+        "name":"Ventus 3T (poly)",
+        "wingArea":"10.84 m**2",
+        "referenceWeight":"430.0 kg",
+        "emptyWeight": "300.0 kg",
+        "polarCoefficients":[-1.86, 0.0298, -0.000170],
+        "polarSpeedUnits":"kph",
+        "polarSinkUnits":"m\/s",
+        "minSpeed":"65 kph",
+        "maxSpeed":"250 kph"
     }
 ]


### PR DESCRIPTION
Note that the LX9000 use V/100 in the polynomial and treats sink as positive. And the coefficients are given in the opposite order. So, the LX9000 equation is sink = A*(V/100)**2 + B*(V/100) + C Where:
A = 1.70
B = -2.98
C = 1.86
So, in the end, with the sign changes, order reversal, and dividing by 100 or 1000, the coefficients for this program become [-1.86, 0.0298, -0.000170],

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ventus 3T (poly) glider to the available aircraft selection. The new glider includes comprehensive technical specifications: 10.84 m² wing area, reference weight of 430 kg, empty weight of 300 kg, and detailed performance coefficients. Speed range covered is 65 to 250 kph with corresponding sink rate data for accurate flight calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->